### PR TITLE
stdlib should also provide malloc() on windows

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "dynarr/dynarr.h"
 #include "parser/parser.h"
 #include "lexer/lexer.h"


### PR DESCRIPTION
malloc.h can't be found on mac. try if it works with stdlib.h on windows too (it really should)